### PR TITLE
allow passing of container command into ecs-service

### DIFF
--- a/modules/ecs-service/README.md
+++ b/modules/ecs-service/README.md
@@ -49,6 +49,7 @@
 | <a name="input_autoscaling_max_capacity"></a> [autoscaling\_max\_capacity](#input\_autoscaling\_max\_capacity) | The maximum number of tasks to provision | `number` | `3` | no |
 | <a name="input_autoscaling_memory_threshold"></a> [autoscaling\_memory\_threshold](#input\_autoscaling\_memory\_threshold) | The desired threashold for memory consumption | `number` | `75` | no |
 | <a name="input_autoscaling_min_capacity"></a> [autoscaling\_min\_capacity](#input\_autoscaling\_min\_capacity) | The minimum number of tasks to provision | `number` | `1` | no |
+| <a name="input_command"></a> [command](#input\_command) | The command that is passed to the container | `list(string)` | `null` | no |
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | The name of the Container specified in the Task definition | `string` | `"app"` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | The port that the container will use to listen to requests | `number` | `8080` | no |
 | <a name="input_cp_strategy_base"></a> [cp\_strategy\_base](#input\_cp\_strategy\_base) | Base number of tasks to create on Fargate on-demand | `number` | `1` | no |

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -97,6 +97,7 @@ module "task_sidecar_containers" {
 
 module "task_main_app_container" {
   source          = "../ecs-container-definition"
+  command         = var.command
   container_image = var.image
   container_name  = var.container_name
   port_mappings = [{

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -144,6 +144,12 @@ variable "sidecar_container_definitions" {
   default     = []
 }
 
+variable "command" {
+  type        = list(string)
+  description = "The command that is passed to the container"
+  default     = null
+}
+
 variable "container_name" {
   description = "The name of the Container specified in the Task definition"
   type        = string


### PR DESCRIPTION
## Description
Add the `command` variable in the ecs-service module so that we can pass the container commands without creating our own ecs-container-definition module

## Motivation and Context
We need to pass custom commands to our containers

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
