### PR TITLE
Ignore capacity provider strategy on ECS service

### DIFF
--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -62,7 +62,8 @@ resource "aws_ecs_service" "this" {
     ignore_changes = [
       desired_count,
       task_definition,
-      load_balancer
+      load_balancer,
+      capacity_provider_strategy
     ]
   }
 }


### PR DESCRIPTION
When an ECS cluster has a default_capacity_provider_strategy setting defined, Terraform will mark all services that don't have

```
  lifecycle {
    ignore_changes = [
      capacity_provider_strategy
    ]
  }
```
to be recreated.