### PR TITLE
Don't destroy task definitions

### DIFF
--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -127,6 +127,7 @@ resource "aws_ecs_task_definition" "this" {
   memory                   = var.memory
   execution_role_arn       = var.execution_role_arn
   task_role_arn            = aws_iam_role.task.arn
+  skip_destroy             = true
 
   container_definitions = jsonencode(
     concat(


### PR DESCRIPTION
We update task definitions outside of Terraform (in CodeDeploy). We don't want Terraform destroying active task definitions.