### PR TITLE
Add option to create and use firelens sidecar to log to opensearch

### DIFF
--- a/modules/ecs-service/README.md
+++ b/modules/ecs-service/README.md
@@ -18,6 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_task_firelens_container"></a> [task\_firelens\_container](#module\_task\_firelens\_container) | ../ecs-container-definition | n/a |
 | <a name="module_task_main_app_container"></a> [task\_main\_app\_container](#module\_task\_main\_app\_container) | ../ecs-container-definition | n/a |
 | <a name="module_task_sidecar_containers"></a> [task\_sidecar\_containers](#module\_task\_sidecar\_containers) | ../ecs-container-definition | n/a |
 
@@ -64,6 +65,7 @@
 | <a name="input_enable_autoscaling"></a> [enable\_autoscaling](#input\_enable\_autoscaling) | Determines whether autoscaling is enabled for the service | `bool` | `false` | no |
 | <a name="input_enable_ecs_managed_tags"></a> [enable\_ecs\_managed\_tags](#input\_enable\_ecs\_managed\_tags) | Specifies whether to enable Amazon ECS managed tags for the tasks within the service. | `bool` | `true` | no |
 | <a name="input_enable_execute_command"></a> [enable\_execute\_command](#input\_enable\_execute\_command) | Specifies whether to enable Amazon ECS Exec for the tasks within the service. | `bool` | `false` | no |
+| <a name="input_enable_firelens"></a> [enable\_firelens](#input\_enable\_firelens) | Whether or not to enable Firelens | `bool` | `false` | no |
 | <a name="input_enable_scheduled_autoscaling"></a> [enable\_scheduled\_autoscaling](#input\_enable\_scheduled\_autoscaling) | Determines whether scheduled autoscaling is enabled for the service | `bool` | `false` | no |
 | <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | ecs-blueprint-infra ECS execution ARN | `string` | n/a | yes |
 | <a name="input_health_check_grace_period_seconds"></a> [health\_check\_grace\_period\_seconds](#input\_health\_check\_grace\_period\_seconds) | Number of seconds for the task health check | `number` | `30` | no |
@@ -74,6 +76,7 @@
 | <a name="input_map_secrets"></a> [map\_secrets](#input\_map\_secrets) | The secrets variables to pass to the container. This is a map of string: {key: value}. map\_secrets overrides secrets | `map(string)` | `null` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The MEMORY value to assign to the container, read AWS documentation to available values | `number` | `512` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name for the ecs service | `string` | n/a | yes |
+| <a name="input_opensearch_domain"></a> [opensearch\_domain](#input\_opensearch\_domain) | Domain name of Opensearch cluster to send logs to | `string` | `null` | no |
 | <a name="input_platform_version"></a> [platform\_version](#input\_platform\_version) | Platform version on which to run your service | `string` | `null` | no |
 | <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are SERVICE and TASK\_DEFINITION. | `string` | `"SERVICE"` | no |
 | <a name="input_scheduled_autoscaling_down_max_capacity"></a> [scheduled\_autoscaling\_down\_max\_capacity](#input\_scheduled\_autoscaling\_down\_max\_capacity) | The maximum number of tasks to provision | `number` | `3` | no |

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -304,3 +304,19 @@ variable "scheduled_autoscaling_down_max_capacity" {
   type        = number
   default     = 3
 }
+
+################################################################################
+# Firelens
+################################################################################
+
+variable "enable_firelens" {
+  description = "Whether or not to enable Firelens"
+  type        = bool
+  default     = false
+}
+
+variable "opensearch_domain" {
+  description = "Domain name of Opensearch cluster to send logs to"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This PR adds the option to create a firelens sidecar container in the ECS service.
If you enable firelens, you must provide an Opensearch cluster domain name for firelens to send the logs to.