### PR TITLE
Add firelensConfiguration object to firelens container

### DIFF
--- a/modules/ecs-container-definition/main.tf
+++ b/modules/ecs-container-definition/main.tf
@@ -92,6 +92,7 @@ locals {
     pseudoTerminal         = var.pseudo_terminal
     dockerSecurityOptions  = var.docker_security_options
     resourceRequirements   = var.resource_requirements
+    firelensConfiguration  = var.firelens_configuration
   }
 
   container_definition_without_null = {

--- a/modules/ecs-container-definition/variables.tf
+++ b/modules/ecs-container-definition/variables.tf
@@ -170,14 +170,14 @@ variable "log_configuration" {
 }
 
 # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html
-# variable "firelens_configuration" {
-#   type = object({
-#     type    = string
-#     options = map(string)
-#   })
-#   description = "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html"
-#   default     = null
-# }
+ variable "firelens_configuration" {
+   type = object({
+     type    = string
+     options = map(string)
+   })
+   description = "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html"
+   default     = null
+ }
 
 # variable "mount_points" {
 #   type = list(any)

--- a/modules/ecs-container-definition/variables.tf
+++ b/modules/ecs-container-definition/variables.tf
@@ -170,14 +170,14 @@ variable "log_configuration" {
 }
 
 # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html
- variable "firelens_configuration" {
-   type = object({
-     type    = string
-     options = map(string)
-   })
-   description = "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html"
-   default     = null
- }
+variable "firelens_configuration" {
+  type = object({
+    type    = string
+    options = map(string)
+  })
+  description = "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html"
+  default     = null
+}
 
 # variable "mount_points" {
 #   type = list(any)

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -129,7 +129,7 @@ module "task_firelens_container" {
   container_image              = "public.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:stable"
   essential                    = true
   container_memory_reservation = 50
-  firelens_configuration       = { "type" : "fluentbit" }
+  firelens_configuration       = { "type" : "fluentbit", "options": {} }
 
   log_configuration = {
     logDriver : "awslogs",

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -129,6 +129,7 @@ module "task_firelens_container" {
   container_image              = "public.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:stable"
   essential                    = true
   container_memory_reservation = 50
+  firelens_configuration       = { "type" : "fluentbit" }
 
   log_configuration = {
     logDriver : "awslogs",

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -34,7 +34,7 @@ resource "aws_ecs_service" "this" {
   cluster = var.ecs_cluster_id
   # launch_type                        = "FARGATE"
   platform_version        = var.platform_version
-  task_definition         = aws_ecs_task_definition.this.arn
+  task_definition         = nonsensitive(aws_ecs_task_definition.this.arn)
   desired_count           = var.desired_count
   enable_ecs_managed_tags = var.enable_ecs_managed_tags
   propagate_tags          = var.propagate_tags

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -167,11 +167,13 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn            = aws_iam_role.task.arn
   skip_destroy             = true
 
-  container_definitions = jsonencode(
-    concat(
-      [module.task_main_app_container.json_map_object],
-      [for fl in module.task_firelens_container : fl.json_map_object],
-      [for sc in module.task_sidecar_containers : sc.json_map_object]
+  container_definitions = nonsensitive(
+    jsonencode(
+      concat(
+        [module.task_main_app_container.json_map_object],
+        [for fl in module.task_firelens_container : fl.json_map_object],
+        [for sc in module.task_sidecar_containers : sc.json_map_object]
+      )
     )
   )
 

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -129,7 +129,7 @@ module "task_firelens_container" {
   container_image              = "public.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:stable"
   essential                    = true
   container_memory_reservation = 50
-  firelens_configuration       = { "type" : "fluentbit", "options": {} }
+  firelens_configuration       = { "type" : "fluentbit", "options" : {} }
 
   log_configuration = {
     logDriver : "awslogs",


### PR DESCRIPTION
## Description
The sidecar container that runs firelens needs to firelensConfiguration object.  Otherwise, the main container doesn't know that the sidecar is there for the purpose of log routing.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
