### PR TITLE
Allow custom fluentbit parser

### DIFF
--- a/modules/ecs-service/README.md
+++ b/modules/ecs-service/README.md
@@ -51,6 +51,8 @@
 | <a name="input_autoscaling_memory_threshold"></a> [autoscaling\_memory\_threshold](#input\_autoscaling\_memory\_threshold) | The desired threashold for memory consumption | `number` | `75` | no |
 | <a name="input_autoscaling_min_capacity"></a> [autoscaling\_min\_capacity](#input\_autoscaling\_min\_capacity) | The minimum number of tasks to provision | `number` | `1` | no |
 | <a name="input_command"></a> [command](#input\_command) | The command that is passed to the container | `list(string)` | `null` | no |
+| <a name="input_config_file_type"></a> [config\_file\_type](#input\_config\_file\_type) | The source location of the custom configuration file. The available options are s3 or file. | `string` | `""` | no |
+| <a name="input_config_file_value"></a> [config\_file\_value](#input\_config\_file\_value) | The source for the custom configuration file. | `string` | `""` | no |
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | The name of the Container specified in the Task definition | `string` | `"app"` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | The port that the container will use to listen to requests | `number` | `8080` | no |
 | <a name="input_cp_strategy_base"></a> [cp\_strategy\_base](#input\_cp\_strategy\_base) | Base number of tasks to create on Fargate on-demand | `number` | `1` | no |

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -13,10 +13,10 @@ locals {
       "Aws_Region" : data.aws_region.current.name,
       "tls" : "On",
       "retry_limit" : "2",
-      "Logstash_Format": true,
-      "Logstash_Prefix": "application",
-      "config-file-type": var.config_file_type,
-      "config-file-value": var.config_file_value
+      "Logstash_Format" : true,
+      "Logstash_Prefix" : "application",
+      "config-file-type" : var.config_file_type,
+      "config-file-value" : var.config_file_value
     }
   }
   default_log_config = {

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -14,7 +14,9 @@ locals {
       "tls" : "On",
       "retry_limit" : "2",
       "Logstash_Format": true,
-      "Logstash_Prefix": "application"
+      "Logstash_Prefix": "application",
+      "config-file-type": var.config_file_type,
+      "config-file-value": var.config_file_value
     }
   }
   default_log_config = {

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -320,3 +320,15 @@ variable "opensearch_domain" {
   type        = string
   default     = null
 }
+
+variable "config_file_type" {
+  description = "The source location of the custom configuration file. The available options are s3 or file."
+  type        = string
+  default     = ""
+}
+
+variable "config_file_value" {
+  description = "The source for the custom configuration file."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Description
Add two variables that will allow us to pass custom configuration files to Firelens


## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

