### PR TITLE
upgrade kinesis firehose container

### DIFF
--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -4,7 +4,7 @@ locals {
   firelens_log_config = {
     logDriver : "awsfirelens",
     "options" : {
-      "Name" : "firehose",
+      "Name" : "kinesis_firehose",
       "region" : data.aws_region.current.name,
       "delivery_stream": "logging",
       "time_key": "@timestamp"


### PR DESCRIPTION
We're getting these messages in our logs:

```
A new higher performance Firehose plugin has been released; you are using the old plugin. Check out the new plugin's documentation and consider migrating.\nhttps://docs.fluentbit.io/manual/pipeline/outputs/firehose"
```

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
