### PR TITLE
chore: DEVOPS-313 Resource allocation for log-router

### DIFF
--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -175,7 +175,7 @@ resource "aws_ecs_task_definition" "this" {
   memory                   = var.memory
   execution_role_arn       = var.execution_role_arn
   task_role_arn            = aws_iam_role.task.arn
-  skip_destroy             = false
+  skip_destroy             = true
 
   container_definitions = jsonencode(
     concat(

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -175,7 +175,7 @@ resource "aws_ecs_task_definition" "this" {
   memory                   = var.memory
   execution_role_arn       = var.execution_role_arn
   task_role_arn            = aws_iam_role.task.arn
-  skip_destroy             = true
+  skip_destroy             = false
 
   container_definitions = jsonencode(
     concat(

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -131,8 +131,8 @@ module "task_firelens_container" {
   container_name               = var.firelens_container_definition[count.index]["container_name"]
   container_image              = var.firelens_container_definition[count.index]["container_image"]
   essential                    = lookup(var.firelens_container_definition[count.index], "essential", true)
-  container_memory             = lookup(var.firelens_container_definition[count.index], "container_memory", true)
-  container_memory_reservation = lookup(var.firelens_container_definition[count.index], "container_memory_reservation", true)
+  container_memory             = lookup(var.firelens_container_definition[count.index], "container_memory", null)
+  container_memory_reservation = lookup(var.firelens_container_definition[count.index], "container_memory_reservation", null)
   container_cpu                = lookup(var.firelens_container_definition[count.index], "container_cpu", 0)
 
   firelens_configuration = {

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -144,6 +144,12 @@ variable "sidecar_container_definitions" {
   default     = []
 }
 
+variable "firelens_container_definition" {
+  description = "Container definition for firelens"
+  type        = list(any)
+  default     = []
+}
+
 variable "command" {
   type        = list(string)
   description = "The command that is passed to the container"


### PR DESCRIPTION
The log-router container will now take parameters from another place allowing us to allocate resource and keep everything similiar between different containers

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
