### PR TITLE
chore(DEVOPS-456): Add main container dependency on log_router container

### DIFF
--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -176,7 +176,7 @@ module "task_main_app_container" {
 
   container_depends_on = [{
     containerName : "log_router",
-    condition : "START"
+    condition : "HEALTHY"
   }]
 }
 

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -170,7 +170,7 @@ module "task_main_app_container" {
 
   container_depends_on = [{
     containerName : "log_router",
-    condition : "HEALTHY"
+    condition : "START"
   }]
 }
 

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -167,6 +167,11 @@ module "task_main_app_container" {
   map_secrets              = var.map_secrets
   map_environment          = var.map_environment
   readonly_root_filesystem = var.readonly_root_filesystem
+
+  container_depends_on = [ {
+    container_name : var.container_name,
+    condition : "HEALTHY"
+  } ]
 }
 
 resource "aws_ecs_task_definition" "this" {

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -169,7 +169,7 @@ module "task_main_app_container" {
   readonly_root_filesystem = var.readonly_root_filesystem
 
   container_depends_on = [{
-    container_name : "log_router",
+    containerName : "log_router",
     condition : "HEALTHY"
   }]
 }

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -152,9 +152,11 @@ module "task_firelens_container" {
   }
 
   healthcheck = {
-    command : ["CMD-SHELL", "curl -f http://localhost/ || exit 1"]
-    retries  = 3
-    interval = 300
+    command     = ["CMD-SHELL", "curl -f http://127.0.0.1:2020/api/v1/uptime || exit 1"]
+    retries     = 2
+    timeout     = 5
+    interval    = 10
+    startPeriod = 30
   }
 }
 

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -150,6 +150,12 @@ module "task_firelens_container" {
       awslogs-stream-prefix : "firelens"
     }
   }
+
+  healthcheck = {
+    command : ["CMD-SHELL", "curl -f http://localhost/ || exit 1"]
+    retries  = 3
+    interval = 300
+  }
 }
 
 module "task_main_app_container" {

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -168,10 +168,10 @@ module "task_main_app_container" {
   map_environment          = var.map_environment
   readonly_root_filesystem = var.readonly_root_filesystem
 
-  container_depends_on = [ {
-    container_name : var.container_name,
+  container_depends_on = [{
+    container_name : "log_router",
     condition : "HEALTHY"
-  } ]
+  }]
 }
 
 resource "aws_ecs_task_definition" "this" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a dependency between the main and the logging container

## JIRA Issue

[DEVOPS-456]

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the main container starts before the log_router container and we have no insight to the reason behind the crash.

[DEVOPS-456]: https://equitymultiple.atlassian.net/browse/DEVOPS-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
